### PR TITLE
Switch to Debian/stretch.  Add gprbuild and more tools.

### DIFF
--- a/gnat/Dockerfile
+++ b/gnat/Dockerfile
@@ -1,5 +1,5 @@
-FROM debian:jessie
+FROM debian:stretch
 MAINTAINER Samuel Tardieu, sam@rfc1149.net
 RUN apt-get update
 RUN apt-get dist-upgrade -y
-RUN apt-get install -y gnat texinfo texlive build-essential wget
+RUN apt-get install -y gnat texinfo texlive build-essential wget mercurial parallel gprbuild


### PR DESCRIPTION
Hi Samuel.
It would be nice to switch your GNAT Docker image to Debian/stretch.  I've added "gprbuild" to the installed packages, as it is the suggested way to build with GNAT nowadays.  "mercurial" and "parallel" are added because I use them quite frequently when building and testing my Ada libraries.
/Jacob